### PR TITLE
added audioUUID flush on user buffer

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -279,6 +279,9 @@ const startRecording = async () => {
   return new Promise(async (resolve, reject) => {
     if (window.MediaRecorder && recordingAllowed && !window.isMuted) {
       try {
+        window.audioUUIDs = window.audioUUIDs.filter(
+          (uuid) => uuid === f.audioUUID
+        );
         window.audioUUIDs.push(f.audioUUID);
         console.log(window.audioUUIDs);
         let maxLength = setTimeout(() => {


### PR DESCRIPTION
Fixed a bug where the old audioUUID was sticking around after a user loaded a custom buffer. Should be fixed now. 